### PR TITLE
[ feat ] 토큰로그인 유지 로직 추가

### DIFF
--- a/next-researchlab/src/components/main-header/main-header.tsx
+++ b/next-researchlab/src/components/main-header/main-header.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import Link from "next/link";
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import styles from "./main-header.module.css";
 
-import { login, logout, Member } from "@/redux/memberActions";
+import { login, logout, Member, setMember } from "@/redux/memberActions";
+import axios from "axios";
 import Button from "../../components/members/button";
 import EnrollModal, {
   EnrollModalHandle,
@@ -34,12 +35,29 @@ const Header = () => {
 
   const handleLogout = async () => {
     try {
-      // await axios.post("api/members/logout", {}, { withCredentials: true });
+      await axios.post("api/auth/logout", {}, { withCredentials: true });
       dispatch(logout(null));
     } catch (error) {
       console.error("로그아웃 실패", error);
     }
   };
+
+  useEffect(() => {
+    const fetchMember = async () => {
+      try {
+        // Spring 백엔드의 인증 확인 API 호출
+        const response = await axios.get("/api/auth/checkJwt", {
+          withCredentials: true,
+        });
+        dispatch(member(response.data));
+      } catch (error) {
+        console.error("Authentication failed:", error);
+        dispatch(setMember(null));
+      }
+    };
+
+    fetchMember();
+  }, [dispatch, member]);
 
   return (
     <>

--- a/next-researchlab/src/redux/memberActions.tsx
+++ b/next-researchlab/src/redux/memberActions.tsx
@@ -9,16 +9,16 @@ const memberSlice = createSlice({
   name: "member",
   initialState,
   reducers: {
-    login: (state: Member | null, action: PayloadAction<Member>) => {
-      localStorage.setItem("loginMember", JSON.stringify(action.payload));
-      console.log("회원정보 로컬스토리지저장");
+    login: (state, action: PayloadAction<Member>) => {
+      // 회원 정보만 Redux 상태에 저장
       return action.payload;
     },
     logout: () => {
-      localStorage.removeItem("loginMember");
+      // 로그아웃 시 상태를 null로 변경
       return null;
     },
-    setMember: (state: Member | null, action: PayloadAction<Member | null>) => {
+    setMember: (state, action: PayloadAction<Member | null>) => {
+      // 서버에서 가져온 회원 정보를 설정
       return action.payload;
     },
   },


### PR DESCRIPTION
1. 컴포넌트 내부에 통신 로직을 구성 -> 이후에 서버요청 로직은 분리예정

2. 리덕스에서 로컬스토리지에 저장하는 것은 삭제 -> 회원정보는 리덕스에서만 관리함